### PR TITLE
Added Apple CDN Debug Headers

### DIFF
--- a/yurllib/utils.go
+++ b/yurllib/utils.go
@@ -40,3 +40,23 @@ func makeRequest(fileURL string) (*http.Response, error) {
 
 	return resp, nil
 }
+
+func CompareStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if v != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func OutputStatus(output []string, name string, pass bool) []string{
+	if pass {		
+		return append(output, fmt.Sprintf("%s: Pass\n", name))
+	} else {
+		return append(output, fmt.Sprintf("%s: Fail\n", name))
+	}
+}


### PR DESCRIPTION
Added apple CDN debug headers 
Eg: 

```
curl https://app-site-association.cdn-apple.com/a/v1/MYDOMAIN -v
*   Trying 17.253.67.202:443...
* Connected to app-site-association.cdn-apple.com (17.253.67.202) port 443 (#0)

...

> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 404 Not Found
< Apple-Failure-Details: {"status":"403 Forbidden"}
< Apple-Failure-Reason: SWCERR00101 Bad HTTP Response: 403 Forbidden
< Apple-From: https://MYDOMAIN/.well-known/apple-app-site-association
< Apple-Try-Direct: false
< Cache-Control: max-age=1800,public
< Content-Length: 10
< Content-Type: text/plain; charset=utf-8
< Date: Fri, 20 Jan 2023 03:03:22 GMT
< Expires: Fri, 20 Jan 2023 03:03:32 GMT
< Age: 1399
< Via: http/1.1 ausyd2-vp-vst-002.ts.apple.com (acdn/176.13298), https/1.1 ausyd2-vp-vfe-008.ts.apple.com (acdn/168.13283), http/1.1 ausyd2-edge-lx-011.ts.apple.com (acdn/59.14204), http/1.1 ausyd2-edge-bx-008.ts.apple.com (acdn/59.14204)

...
```

adds new output:


Apple CDN Debug Headers: https://app-site-association.cdn-apple.com/a/v1/MYDOMAIN 
AppleFailureDetails: 	 [{"status":"403 Forbidden"}] 
AppleFailureReason: 	 [SWCERR00101 Bad HTTP Response: 403 Forbidden] 
AppleFrom: 				 [https://MYDOMAIN/.well-known/apple-app-site-association] 
AppleTryDirect: 		 [false] 
CacheControl: 			 [max-age=1800,public] 
ContentLength: 			 [10] 
Date: 					 [Fri, 20 Jan 2023 04:15:46 GMT] 
Expires: 				 [Fri, 20 Jan 2023 04:15:57 GMT] 
Via: 					 [https/1.1 ausyd2-vp-vst-003.ts.apple.com (acdn/176.13298), https/1.1 ausyd2-vp-vfe-005.ts.apple.com (acdn/168.13283), http/1.1 ausyd2-edge-lx-011.ts.apple.com (acdn/59.14204), http/1.1 ausyd2-edge-bx-017.ts.apple.com (acdn/59.14204)] 
Age: 					 [1538] 
