### PR TITLE
Bug: Incorrectly reports android deeplinks as invalid for app.links urls

### DIFF
--- a/yurllib/aasa.go
+++ b/yurllib/aasa.go
@@ -78,7 +78,14 @@ func CheckAASADomain(inputURL string, bundleIdentifier string, teamIdentifier st
 
 	if len(contentType) > 0 {
 		isEncryptedMimeType = contentType[0] == "application/pkcs7-mime"
-		isJSONMimeType := contentType[0] == "application/json" || contentType[0] == "text/json" || contentType[0] == "text/plain" || strings.Contains(contentType[0], "application/json") || contentType[0] == "application/octet-stream" || contentType[0] == "binary/octet-stream"
+		
+		isJSONMimeType := contentType[0] == "application/json"||
+			contentType[0] == "text/json" ||
+			contentType[0] == "text/plain" ||
+			strings.Contains(contentType[0], "application/json") ||
+			contentType[0] == "application/octet-stream" ||
+			contentType[0] == "binary/octet-stream"
+
 		isJSONTypeOK = allowUnencrypted && isJSONMimeType // Only ok if both the "allow" flag is true, and... it's a valid type.
 	} else {
 		isJSONTypeOK = true

--- a/yurllib/assetlink.go
+++ b/yurllib/assetlink.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 )
 
 type assetLinkFile []struct {
@@ -47,8 +48,11 @@ func CheckAssetLinkDomain(inputURL string, packageInput string, fingerprintInput
 
 	output = append(output, fmt.Sprintf("Content-type: \t\t\t  %s \n", contentType))
 
-	if contentType[0] != "application/json" {
-		output = append(output, fmt.Sprint("\nInvalid content type. Expecting [application/json]. Please update and test again. \n"))
+	isJSONMimeType := strings.Contains(contentType[0], "application/json")
+
+	if !isJSONMimeType {
+		output = append(output, fmt.Sprintf("Invalid content-type: \t\t  %s \n", contentType))
+		// output = append(output, fmt.Sprint("\nInvalid content type. Expecting [application/json]. Please update and test again. \n"))
 		output = append(output, fmt.Sprint("\nIf you believe this error is invalid, please open an issue on github or email support@chayev.com and we will investigate."))
 		return output
 	}


### PR DESCRIPTION
Resolves [#79](https://github.com/chayev/yurl/issues/79)

Bug: Incorrectly reports android deeplinks as invalid if contains anything other than application/json in the header

Fix: services such as app.link return content-type headers: `application/json; charset=utf-8` and work fine with ios and android. Android yURL results currently wrongly state this is invalid.

Switched: `contentType[0] != "application/json"` to  `isJSONMimeType := strings.Contains(contentType[0], "application/json")`